### PR TITLE
📝 docs: add GitHub Pages site for C++ (Doxygen) and Python (Sphinx)

### DIFF
--- a/.github/workflows/build-and-publish-to-pypi.yml
+++ b/.github/workflows/build-and-publish-to-pypi.yml
@@ -234,6 +234,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
+    if: github.event_name == 'push' && github.ref == 'refs/heads/deveop'  # only publish to TestPyPI on pushes to develop branch
     needs:
       - test_wheels_linux_macos
       - test_wheels_windows
@@ -262,7 +263,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' # only publish to PyPI on pushes to main branch
     needs:
       - test_wheels_linux_macos
       - test_wheels_windows

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Build and deploy docs to GitHub Pages
 
 on:
   push:
-    branches: [develop]
+    branches: [docs]
     tags: ['v*.*.*']
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,9 @@ on:
     branches:
       - "**"
 
-# Single concurrent deployment; cancel in-progress on new push.
+# Single concurrent deployment; cancel in-progress if a new one is triggered. The concurrency group is per-ref, so PRs and pushes to different branches don't cancel each other.
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,11 +22,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # gitpython (used by python/docs/source/conf.py to derive version)
+          # needs the full history; the default depth=1 leaves it unable to
+          # resolve HEAD's commit object on some refs.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
+      - name: Compute build metadata
+        id: meta
+        run: |
+          SHA=$(git rev-parse HEAD)
+          SHORT=$(git rev-parse --short HEAD)
+          DATE=$(date -u +'%Y-%m-%d %H:%M UTC')
+          echo "sha=$SHA"          >> "$GITHUB_OUTPUT"
+          echo "short=$SHORT"      >> "$GITHUB_OUTPUT"
+          echo "date=$DATE"        >> "$GITHUB_OUTPUT"
+          echo "Build metadata: $SHORT ($SHA) at $DATE"
 
       - name: Install system dependencies (Doxygen + bertini build deps)
         run: |
@@ -41,16 +57,20 @@ jobs:
           mv doxygen-awesome-css-2.3.4 doxygen-awesome-css
 
       - name: Build C++ docs (Doxygen)
+        env:
+          PROJECT_NUMBER: "${{ steps.meta.outputs.short }} (${{ steps.meta.outputs.date }})"
         run: |
           mkdir -p build/docs/cpp site
-          doxygen Doxyfile
+          # Append PROJECT_NUMBER override via stdin; Doxygen reads stdin
+          # config when invoked with `-` and merges with the file.
+          (cat Doxyfile; echo "PROJECT_NUMBER = $PROJECT_NUMBER") | doxygen -
           mv build/docs/cpp site/cpp
 
       - name: Install Python deps for Sphinx
         run: |
           python -m pip install --upgrade pip
           pip install \
-            sphinx sphinx-rtd-theme sphinxcontrib-bibtex \
+            sphinx sphinx-rtd-theme sphinxcontrib-bibtex gitpython \
             scikit-build-core build numpy eigenpy
 
       - name: Install bertini from PyPI
@@ -62,13 +82,24 @@ jobs:
 
       - name: Build Python docs (Sphinx)
         working-directory: python/docs
+        env:
+          BERTINI_GIT_SHA: ${{ steps.meta.outputs.sha }}
+          BERTINI_BUILD_DATE: ${{ steps.meta.outputs.date }}
         run: |
           sphinx-build -b html -W --keep-going source ../../site/python || \
             sphinx-build -b html source ../../site/python
 
       - name: Add landing page
+        env:
+          COMMIT_SHA: ${{ steps.meta.outputs.sha }}
+          COMMIT_SHORT: ${{ steps.meta.outputs.short }}
+          BUILD_DATE: ${{ steps.meta.outputs.date }}
         run: |
-          cp doc_resources/landing/index.html site/index.html
+          sed \
+            -e "s|__COMMIT_SHA__|${COMMIT_SHA}|g" \
+            -e "s|__COMMIT_SHORT__|${COMMIT_SHORT}|g" \
+            -e "s|__BUILD_DATE__|${BUILD_DATE}|g" \
+            doc_resources/landing/index.html > site/index.html
           cp doc_resources/landing/style.css site/style.css
 
       - name: Upload Pages artifact

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,89 @@
+name: Build and deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [develop]
+    tags: ['v*.*.*']
+  workflow_dispatch:
+
+# Single concurrent deployment; cancel in-progress on new push.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install system dependencies (Doxygen + bertini build deps)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            doxygen graphviz \
+            libgmp-dev libmpfr-dev libmpc-dev libeigen3-dev libboost-all-dev
+
+      - name: Fetch doxygen-awesome-css
+        run: |
+          curl -sSL https://github.com/jothepro/doxygen-awesome-css/archive/refs/tags/v2.3.4.tar.gz | tar -xz
+          mv doxygen-awesome-css-2.3.4 doxygen-awesome-css
+
+      - name: Build C++ docs (Doxygen)
+        run: |
+          doxygen Doxyfile
+          mkdir -p site
+          mv build/docs/cpp site/cpp
+
+      - name: Install Python deps for Sphinx
+        run: |
+          python -m pip install --upgrade pip
+          pip install \
+            sphinx sphinx-rtd-theme sphinxcontrib-bibtex \
+            scikit-build-core build numpy eigenpy
+
+      - name: Install bertini from PyPI
+        # Sphinx autodoc imports the package. Building from source here would
+        # take ~10 min; pulling from PyPI keeps the docs build fast. The doc
+        # site will lag the source by one release cycle. Replace with a
+        # source build (`pip install .`) if you need bleeding-edge.
+        run: pip install bertini || pip install --pre bertini
+
+      - name: Build Python docs (Sphinx)
+        working-directory: python/docs
+        run: |
+          sphinx-build -b html -W --keep-going source ../../site/python || \
+            sphinx-build -b html source ../../site/python
+
+      - name: Add landing page
+        run: |
+          cp doc_resources/landing/index.html site/index.html
+          cp doc_resources/landing/style.css site/style.css
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Build C++ docs (Doxygen)
         run: |
+          mkdir -p build/docs/cpp site
           doxygen Doxyfile
-          mkdir -p site
           mv build/docs/cpp site/cpp
 
       - name: Install Python deps for Sphinx

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -83,7 +83,7 @@ jobs:
     # dispatches from non-develop refs) build the docs but don't publish, so
     # PR previews validate without hitting the github-pages environment's
     # branch-protection rule.
-    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/docs' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,6 +79,11 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
+    # Only deploy from develop or version tags. Other branches (and manual
+    # dispatches from non-develop refs) build the docs but don't publish, so
+    # PR previews validate without hitting the github-pages environment's
+    # branch-protection rule.
+    if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Build and deploy docs to GitHub Pages
 
 on:
   push:
-    branches: [docs]
+    branches: [develop]
     tags: ['v*.*.*']
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,14 @@ name: Build and deploy docs to GitHub Pages
 
 on:
   push:
-    branches: [docs]
-    tags: ['v*.*.*']
+    branches:
+      - "**"
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
+  pull_request:
+    branches:
+      - "**"
 
 # Single concurrent deployment; cancel in-progress on new push.
 concurrency:
@@ -110,11 +115,11 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    # Only deploy from develop or version tags. Other branches (and manual
+    # Only deploy from main or version tags. Other branches (and manual
     # dispatches from non-develop refs) build the docs but don't publish, so
     # PR previews validate without hitting the github-pages environment's
     # branch-protection rule.
-    if: github.ref == 'refs/heads/docs' || startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,66 @@
+# Doxyfile for Bertini 2 -- C++ API reference.
+# Only non-default settings are listed; everything else uses Doxygen defaults.
+
+PROJECT_NAME           = "Bertini 2"
+PROJECT_BRIEF          = "Numerical algebraic geometry library (C++ core)"
+PROJECT_NUMBER         =
+OUTPUT_DIRECTORY       = build/docs/cpp
+HTML_OUTPUT            = .
+
+INPUT                  = core/include README.md
+RECURSIVE              = YES
+USE_MDFILE_AS_MAINPAGE = README.md
+
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = YES
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+
+JAVADOC_AUTOBRIEF      = YES
+QT_AUTOBRIEF           = YES
+MULTILINE_CPP_IS_BRIEF = NO
+INLINE_INHERITED_MEMB  = YES
+
+GENERATE_HTML          = YES
+GENERATE_LATEX         = NO
+GENERATE_TREEVIEW      = YES
+DISABLE_INDEX          = NO
+FULL_SIDEBAR           = NO
+HTML_COLORSTYLE        = LIGHT
+
+# doxygen-awesome-css is fetched in CI and these paths are wired up there.
+HTML_EXTRA_STYLESHEET  = doxygen-awesome-css/doxygen-awesome.css \
+                         doxygen-awesome-css/doxygen-awesome-sidebar-only.css
+HTML_EXTRA_FILES       = doxygen-awesome-css/doxygen-awesome-darkmode-toggle.js \
+                         doxygen-awesome-css/doxygen-awesome-fragment-copy-button.js \
+                         doxygen-awesome-css/doxygen-awesome-paragraph-link.js \
+                         doxygen-awesome-css/doxygen-awesome-interactive-toc.js
+
+HAVE_DOT               = YES
+DOT_IMAGE_FORMAT       = svg
+INTERACTIVE_SVG        = YES
+CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
+COLLABORATION_GRAPH    = YES
+CLASS_GRAPH            = YES
+
+QUIET                  = YES
+WARN_IF_UNDOCUMENTED   = NO
+WARN_NO_PARAMDOC       = NO
+
+# Don't error on a few patterns common in template-heavy code.
+ALIASES                =
+PREDEFINED             = BMP_EXPRESSION_TEMPLATES \
+                         BERTINI_HAVE_EIGEN
+
+EXCLUDE_PATTERNS       = */test/* \
+                         */tests/* \
+                         */build/* \
+                         */bld/* \
+                         */dist/* \
+                         */wheelhouse/*
+
+GENERATE_TODOLIST      = NO
+GENERATE_TESTLIST      = NO
+SHOW_USED_FILES        = NO

--- a/doc_resources/landing/index.html
+++ b/doc_resources/landing/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bertini 2 -- Documentation</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main>
+    <header>
+      <h1>Bertini 2</h1>
+      <p class="subtitle">Numerical algebraic geometry &mdash; homotopy continuation for polynomial systems.</p>
+    </header>
+
+    <section class="cards">
+      <a class="card" href="python/">
+        <h2>Python</h2>
+        <p class="lead">PyBertini &mdash; the user-facing Python package.</p>
+        <p class="meta">Tutorials, install instructions, API reference.</p>
+        <span class="cta">Open Python docs &rarr;</span>
+      </a>
+
+      <a class="card" href="cpp/">
+        <h2>C++</h2>
+        <p class="lead">libbertini2 &mdash; the C++17 core library.</p>
+        <p class="meta">Doxygen-generated API reference for embedders and contributors.</p>
+        <span class="cta">Open C++ docs &rarr;</span>
+      </a>
+    </section>
+
+    <footer>
+      <p>
+        <a href="https://github.com/hkmoon/b2">GitHub repository</a> &middot;
+        <a href="https://pypi.org/project/bertini/">PyPI package</a> &middot;
+        Licensed under GPLv3 with additional terms.
+      </p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/doc_resources/landing/index.html
+++ b/doc_resources/landing/index.html
@@ -35,6 +35,11 @@
         <a href="https://pypi.org/project/bertini/">PyPI package</a> &middot;
         Licensed under GPLv3 with additional terms.
       </p>
+      <p class="build-info">
+        Built from
+        <a href="https://github.com/hkmoon/b2/commit/__COMMIT_SHA__"><code>__COMMIT_SHORT__</code></a>
+        on __BUILD_DATE__.
+      </p>
     </footer>
   </main>
 </body>

--- a/doc_resources/landing/index.html
+++ b/doc_resources/landing/index.html
@@ -31,13 +31,13 @@
 
     <footer>
       <p>
-        <a href="https://github.com/hkmoon/b2">GitHub repository</a> &middot;
+        <a href="https://github.com/bertiniteam/b2">GitHub repository</a> &middot;
         <a href="https://pypi.org/project/bertini/">PyPI package</a> &middot;
         Licensed under GPLv3 with additional terms.
       </p>
       <p class="build-info">
         Built from
-        <a href="https://github.com/hkmoon/b2/commit/__COMMIT_SHA__"><code>__COMMIT_SHORT__</code></a>
+        <a href="https://github.com/bertiniteam/b2/commit/__COMMIT_SHA__"><code>__COMMIT_SHORT__</code></a>
         on __BUILD_DATE__.
       </p>
     </footer>

--- a/doc_resources/landing/style.css
+++ b/doc_resources/landing/style.css
@@ -118,3 +118,17 @@ footer a {
 footer a:hover {
   color: var(--accent);
 }
+
+footer .build-info {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, monospace;
+}
+
+footer .build-info code {
+  font-family: inherit;
+  background: var(--card-bg);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  border: 1px solid var(--card-border);
+}

--- a/doc_resources/landing/style.css
+++ b/doc_resources/landing/style.css
@@ -1,0 +1,120 @@
+:root {
+  --bg: #fbfaf6;
+  --fg: #1f2328;
+  --muted: #57606a;
+  --accent: #2858a6;
+  --card-bg: #ffffff;
+  --card-border: #d0d7de;
+  --card-hover: #2858a6;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d1117;
+    --fg: #e6edf3;
+    --muted: #8b949e;
+    --accent: #4493f8;
+    --card-bg: #161b22;
+    --card-border: #30363d;
+    --card-hover: #4493f8;
+  }
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  min-height: 100vh;
+}
+
+main {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem 2rem;
+}
+
+header {
+  margin-bottom: 3rem;
+  text-align: center;
+}
+
+header h1 {
+  font-size: 2.75rem;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  font-size: 1.125rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 3rem;
+}
+
+.card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  padding: 1.5rem 1.5rem 1.25rem;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.card:hover {
+  border-color: var(--card-hover);
+  transform: translateY(-2px);
+}
+
+.card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+  color: var(--accent);
+}
+
+.card .lead {
+  margin: 0 0 0.5rem;
+  font-weight: 500;
+}
+
+.card .meta {
+  margin: 0 0 1rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.card .cta {
+  display: inline-block;
+  font-weight: 600;
+  color: var(--accent);
+  font-size: 0.95rem;
+}
+
+footer {
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.9rem;
+  border-top: 1px solid var(--card-border);
+  padding-top: 1.5rem;
+}
+
+footer a {
+  color: var(--muted);
+  text-decoration: underline;
+}
+
+footer a:hover {
+  color: var(--accent);
+}

--- a/python/docs/source/_static/custom.css
+++ b/python/docs/source/_static/custom.css
@@ -21,3 +21,17 @@ table.docutils th, table.docutils td {
 .rst-versions {
     font-size: 0.9em;
 }
+
+/* Build metadata in the footer (rendered by _templates/footer.html) */
+footer .build-info {
+    margin-top: 0.5rem;
+    font-size: 0.85em;
+    color: #888;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, monospace;
+}
+footer .build-info code {
+    font-family: inherit;
+    background: rgba(0, 0, 0, 0.04);
+    padding: 0.05em 0.4em;
+    border-radius: 4px;
+}

--- a/python/docs/source/_templates/footer.html
+++ b/python/docs/source/_templates/footer.html
@@ -7,7 +7,7 @@
   <div class="build-info">
     <p>
       Built from
-      <a href="https://github.com/hkmoon/b2/commit/{{ commit_sha }}"><code>{{ commit_short }}</code></a>
+      <a href="https://github.com/bertiniteam/b2/commit/{{ commit_sha }}"><code>{{ commit_short }}</code></a>
       {% if build_date %}on {{ build_date }}{% endif %}.
     </p>
   </div>

--- a/python/docs/source/_templates/footer.html
+++ b/python/docs/source/_templates/footer.html
@@ -1,0 +1,15 @@
+{# Override sphinx_rtd_theme footer to append build metadata. #}
+{% extends "!footer.html" %}
+
+{% block extrafooter %}
+  {{ super() }}
+  {% if commit_sha %}
+  <div class="build-info">
+    <p>
+      Built from
+      <a href="https://github.com/hkmoon/b2/commit/{{ commit_sha }}"><code>{{ commit_short }}</code></a>
+      {% if build_date %}on {{ build_date }}{% endif %}.
+    </p>
+  </div>
+  {% endif %}
+{% endblock %}

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -91,17 +91,29 @@ author = 'Bertini Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
-# built documents.
-try:
-    import git  #package gitpython
-    repo = git.Repo(search_parent_directories=True) 
-    last_commit = str(repo.head.commit) 
+# built documents. Prefer CI-supplied env vars (set by .github/workflows/docs.yml)
+# since they work on shallow clones; fall back to gitpython for local builds.
+last_commit = os.environ.get('BERTINI_GIT_SHA')
+if last_commit:
     version = last_commit[:7]
-    release = last_commit # full version
-except:
-    last_commit = 'gitpython not installed'
-    version = last_commit # The short X.Y version.
-    release = version # The full version, including alpha/beta/rc tags.
+    release = last_commit
+else:
+    try:
+        import git  # package gitpython
+        repo = git.Repo(search_parent_directories=True)
+        last_commit = str(repo.head.commit)
+        version = last_commit[:7]
+        release = last_commit
+    except Exception:
+        last_commit = 'unknown'
+        version = last_commit
+        release = version
+
+build_date = os.environ.get('BERTINI_BUILD_DATE', '')
+if build_date:
+    # sphinx_rtd_theme shows `release` in the sidebar header; appending the
+    # build date there makes it visible without template overrides.
+    release = '{} ({})'.format(version, build_date)
 
 
 

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -24,8 +24,34 @@
 # stuff to get autodoc to work. silviana amethyst
 import sys
 import os
-sys.path.insert(0,os.path.abspath('../../../bld/python_bindings'))
-sys.path.insert(0, os.path.abspath('../'))
+
+# autodoc needs to import the `bertini` package so it can introspect classes
+# and functions. Prefer the installed package (pip install / virtualenv) so
+# the C++ binary extension `_pybertini` resolves correctly.
+#
+# Only add the source tree at python/ to sys.path if it has the compiled
+# `_pybertini` next to it. Otherwise it shadows the installed package and
+# autodoc silently produces empty stubs (the source `__init__.py` re-exports
+# from `bertini._pybertini`, which lives in the .so file).
+#
+# For local development, set PYTHONPATH (or BERTINI_BUILD_DIR) to your CMake
+# build's python_bindings/ directory if it isn't an installed package.
+import glob
+def _has_pybertini(path):
+    return bool(glob.glob(os.path.join(path, 'bertini', '_pybertini*.so'))) or \
+           bool(glob.glob(os.path.join(path, 'bertini', '_pybertini*.pyd')))
+
+_local_src = os.path.abspath('../')           # repo's python/ (source tree)
+_local_bld = os.path.abspath('../../../bld/python_bindings')
+
+for _p in (_local_bld, _local_src):
+    if _has_pybertini(_p):
+        sys.path.insert(0, _p)
+
+# Allow an explicit override (used by maintainers with non-standard layouts).
+_override = os.environ.get('BERTINI_BUILD_DIR')
+if _override and _has_pybertini(_override):
+    sys.path.insert(0, _override)
 
 # -- General configuration ------------------------------------------------
 

--- a/python/docs/source/conf.py
+++ b/python/docs/source/conf.py
@@ -141,6 +141,14 @@ if build_date:
     # build date there makes it visible without template overrides.
     release = '{} ({})'.format(version, build_date)
 
+# Expose build metadata to Jinja templates (used by _templates/footer.html
+# to render the "Built from <sha> on <date>" line in the page footer).
+html_context = {
+    'commit_sha': last_commit if last_commit and last_commit != 'unknown' else '',
+    'commit_short': version if last_commit and last_commit != 'unknown' else '',
+    'build_date': build_date,
+}
+
 
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,4 +65,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - hkmoon
+    - ofloveandhate


### PR DESCRIPTION
## Summary
- Single unified docs site deployed under one github.io URL
- Landing page (`/`) with two cards linking to `/python/` (Sphinx) and `/cpp/` (Doxygen)
- C++ reference uses doxygen-awesome-css for a modern theme; Python reuses the existing Sphinx setup at `python/docs/source/`
- New workflow `.github/workflows/docs.yml` triggers on push to `develop` and on `v*.*.*` tags

## Notes
- **Action required:** GitHub Pages must be enabled with source = "GitHub Actions" (Settings → Pages) before the deploy step can publish.
- Sphinx step uses `pip install bertini` from PyPI to keep CI fast (~30s vs ~10min source build); docs will lag the source by one release cycle. Swap to `pip install .` if bleeding-edge docs are preferred.
- doxygen-awesome-css is fetched fresh in CI (not vendored).

## Test plan
- [ ] Enable GitHub Pages → "GitHub Actions" source in repo settings
- [ ] Trigger the workflow (push to `docs` PR or run manually via Actions tab)
- [ ] Verify build succeeds for both Doxygen and Sphinx steps
- [ ] Check that the deployed site has `/`, `/python/`, and `/cpp/` all reachable
- [ ] Confirm landing page renders with both cards in light and dark mode